### PR TITLE
FIX: hashlib.md5 now requires encoded strings with Python 3.

### DIFF
--- a/edmbutton/edm_button.py
+++ b/edmbutton/edm_button.py
@@ -107,7 +107,7 @@ class PyDMEDMDisplayButton(PyDMRelatedDisplayButton):
         """
         window_name = os.path.basename(filename)
         if macro_string:
-            window_name += hashlib.md5(macro_string).hexdigest()[0:5]
+            window_name += hashlib.md5(macro_string.encode('utf-8')).hexdigest()[0:5]
         return window_name
     
     @classmethod


### PR DESCRIPTION
Came across this issue when running lcls_home with Python 3.

```
[2020-07-16 16:16:53,903] [WARNING ] - Could not access directory service, using cached areas and subsystems.
[2020-07-16 16:18:53,251] [ERROR   ] - Failed to open display.
Traceback (most recent call last):
  File "/reg/g/pcds/pyps/apps/dev/pythonpath/pydm/widgets/related_display_button.py", line 274, in push_button_release_event
    target=None)
  File "/reg/neh/home/slepicka/sandbox/git-slaclab/edmbutton/edmbutton/edm_button.py", line 203, in open_display
    self.open_edm_display(filename, macro_string, in_new_window=(target==self.NEW_WINDOW))
  File "/reg/neh/home/slepicka/sandbox/git-slaclab/edmbutton/edmbutton/edm_button.py", line 123, in open_edm_display
    wname = cls.window_name(filename, macro_string)
  File "/reg/neh/home/slepicka/sandbox/git-slaclab/edmbutton/edmbutton/edm_button.py", line 110, in window_name
    window_name += hashlib.md5(macro_string).hexdigest()[0:5]
TypeError: Unicode-objects must be encoded before hashing
```

With this patch it seems to work. I am not sure if it will still be valid with Python 2. I guess it will be.