### PR TITLE
Add workflow for automatically publishing to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,57 @@
+# This workflow will run when a new release is published and upload it to PyPI using trusted publishing.
+# Done in two separate build and publish jobs per suggested best practice for limiting scope of token usage.
+# https://github.com/pypa/gh-action-pypi-publish
+
+name: Publish - PyPI
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+jobs:
+  build:
+    if: ${{ github.repository == 'jbellister-slac/edmbutton' }}
+    name: Build new release
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build Package
+      run: python -m build
+
+    - name: Upload package
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: package
+        path: dist/*
+        retention-days: 1
+
+  publish:
+    if: ${{ github.repository == 'jbellister-slac/edmbutton' }}
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Used for trusted publishing
+    steps:
+      - name: Download package
+        uses: actions/download-artifact@v4.3.0
+        with:
+          name: package
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -53,5 +53,3 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -39,6 +39,7 @@ jobs:
         retention-days: 1
 
   publish:
+    needs: build
     if: ${{ github.repository == 'jbellister-slac/edmbutton' }}
     name: Publish release to PyPI
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,10 +8,9 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
 jobs:
   build:
-    if: ${{ github.repository == 'jbellister-slac/edmbutton' }}
+    if: ${{ github.repository == 'slaclab/edmbutton' }}
     name: Build new release
     runs-on: ubuntu-latest
 
@@ -40,7 +39,7 @@ jobs:
 
   publish:
     needs: build
-    if: ${{ github.repository == 'jbellister-slac/edmbutton' }}
+    if: ${{ github.repository == 'slaclab/edmbutton' }}
     name: Publish release to PyPI
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Context

A belated follow-up to #13.

Adds the github workflow for publishing to PyPI automatically when a new release is published.

Uses the recommended workflow here:
https://github.com/pypa/gh-action-pypi-publish

### Testing

Ran this workflow on my fork, confirmed it published a fake test release to test pypi

https://test.pypi.org/project/edmbutton/

![Screenshot from 2025-06-27 16-00-27](https://github.com/user-attachments/assets/9447c7b7-c902-4c58-8b82-6dd17dd1ba6f)
